### PR TITLE
default.xml: add meta-linaro

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,5 +19,6 @@
   <project path="sources/meta-backports" name="openembedded/meta-backports" remote="linaro"/>
   <project path="sources/openembedded-core" name="openembedded/openembedded-core"/>
   <project path="sources/openembedded-core/bitbake" name="openembedded/bitbake" revision="1.28"/>
+  <project path="sources/meta-linaro" name="openembedded/meta-linaro" remote="linaro"/>
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -7,18 +7,18 @@
 
   <default remote="github" revision="jethro" sync-j="2"/>
 
-  <project path="sources/conf" name="ndechesne/qcom-oe-setup" revision="master">
+  <project path="layers/conf" name="ndechesne/qcom-oe-setup" revision="master">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
 
-  <project path="sources/meta-96boards" name="96boards/meta-96boards" revision="master"/>
-  <project path="sources/meta-browser" name="linaro-home/meta-browser" revision="chromium_45"/>
-  <project path="sources/meta-openembedded" name="openembedded/meta-openembedded"/>
-  <project path="sources/meta-qcom" name="ndechesne/meta-qcom" revision="master"/>
-  <project path="sources/meta-rpb" name="96boards/meta-rpb" revision="master"/>
-  <project path="sources/meta-backports" name="openembedded/meta-backports" remote="linaro"/>
-  <project path="sources/openembedded-core" name="openembedded/openembedded-core"/>
-  <project path="sources/openembedded-core/bitbake" name="openembedded/bitbake" revision="1.28"/>
-  <project path="sources/meta-linaro" name="openembedded/meta-linaro" remote="linaro"/>
+  <project path="layers/meta-96boards" name="96boards/meta-96boards" revision="master"/>
+  <project path="layers/meta-browser" name="linaro-home/meta-browser" revision="chromium_45"/>
+  <project path="layers/meta-openembedded" name="openembedded/meta-openembedded"/>
+  <project path="layers/meta-qcom" name="ndechesne/meta-qcom" revision="master"/>
+  <project path="layers/meta-rpb" name="96boards/meta-rpb" revision="master"/>
+  <project path="layers/meta-backports" name="openembedded/meta-backports" remote="linaro"/>
+  <project path="layers/openembedded-core" name="openembedded/openembedded-core"/>
+  <project path="layers/openembedded-core/bitbake" name="openembedded/bitbake" revision="1.28"/>
+  <project path="layers/meta-linaro" name="openembedded/meta-linaro" remote="linaro"/>
 
 </manifest>


### PR DESCRIPTION
meta-rpb wants to use the linaro toolchain, so add meta-linaro so it will be
available.

Signed-off-by: Trevor Woerner twoerner@gmail.com
